### PR TITLE
Add additional dependencies so UATs can be run on slaves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
       xvfb \
       libxss1 \
       gconf2 \
+      libasound2 \
  && rm -rf /var/lib/apt/lists/* \
  && pip install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
       openssh-client \
       python-pip \
       xvfb \
+      libxss1 \
  && rm -rf /var/lib/apt/lists/* \
  && pip install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
       python-pip \
       xvfb \
       libxss1 \
+      gconf2 \
  && rm -rf /var/lib/apt/lists/* \
  && pip install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
       git \
       openssh-client \
       python-pip \
+      xvfb \
  && rm -rf /var/lib/apt/lists/* \
  && pip install awscli
 


### PR DESCRIPTION
This adds some additional libraries so that you can run Nightmare(possibly others) UATs natively on the slaves. It essentially allows you to use a virtual frame buffer to render on the slave.